### PR TITLE
Add slugify filename ASCII regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,5 @@
 - Moved legacy pdfminer-only script to `scripts/legacy`
 - Test ensures Markdown output is non-empty and ASCII
 - Removed pytest-of-root directory from repository and added to .gitignore
+- Filenames are now slugified to ASCII-only names with new tests
+- Added regression test to ensure slugified Markdown filenames stay ASCII-only

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -14,3 +14,5 @@
 - [x] Added script for batch PDF conversion by folder
 - [x] Validate Markdown output not empty via CLI test
 - [x] Remove pytest output directory from repository
+- [x] Slugify filenames in converter and add test
+- [x] Add regression test to ensure slugified filenames are not corrupted

--- a/TODO.md
+++ b/TODO.md
@@ -9,3 +9,5 @@
 - [x] Ensure CLI tests validate Markdown output not empty
 - [ ] Add integration test for convert_folder script
 - [x] Remove pytest output directory from repository and ignore in git
+- [x] Slugify filenames for Markdown output
+- [x] Add regression test to ensure slugified filenames are ASCII

--- a/pdf_to_md/converter.py
+++ b/pdf_to_md/converter.py
@@ -1,4 +1,15 @@
 from pathlib import Path
+import unicodedata
+import re
+
+
+def slugify(text: str) -> str:
+    """Return an ASCII-only slug suitable for filenames."""
+    normalized = unicodedata.normalize("NFKD", text)
+    ascii_text = normalized.encode("ascii", "ignore").decode("ascii")
+    slug = re.sub(r"[^A-Za-z0-9]+", "_", ascii_text).strip("_")
+    return slug or "file"
+
 try:
     from pdfminer.high_level import extract_text
     _has_pdfminer = True
@@ -82,7 +93,8 @@ def convert_pdf_to_md(
     Returns
     -------
     Path
-        The path to the generated Markdown file.
+        The path to the generated Markdown file. The filename is an ASCII-only
+        slug derived from the PDF stem.
     """
     out_dir.mkdir(parents=True, exist_ok=True)
     # attempt extraction with pdfminer; if no text found, fall back to OCR
@@ -92,7 +104,8 @@ def convert_pdf_to_md(
         text = ocr_pdf_text(pdf_path, lang=lang)
         if not text.strip():
             print(f"Warning: no text extracted from {pdf_path}", file=sys.stderr)
-    out_path = out_dir / (pdf_path.stem + ".md")
+    out_name = slugify(pdf_path.stem) + ".md"
+    out_path = out_dir / out_name
     out_path.write_text(text)
     if not silent:
         print(f"Converted {pdf_path} -> {out_path}")

--- a/tests/test_slugify_conversion.py
+++ b/tests/test_slugify_conversion.py
@@ -1,0 +1,38 @@
+import pytest
+from pathlib import Path
+
+reportlab = pytest.importorskip('reportlab')
+from reportlab.pdfgen import canvas
+from reportlab.lib.pagesizes import letter
+
+from pdf_to_md.converter import convert_pdf_to_md, slugify
+
+
+def test_slugified_filename(tmp_path):
+    pdf_name = 'Gr\u00f6\u00df\u00e9 F\u00efl\u00e9.pdf'
+    pdf_path = tmp_path / pdf_name
+    c = canvas.Canvas(str(pdf_path), pagesize=letter)
+    c.drawString(100, 750, 'slugify test')
+    c.save()
+
+    out_dir = tmp_path / 'out'
+    out_file = convert_pdf_to_md(pdf_path, out_dir, silent=True)
+
+    expected_name = slugify(pdf_path.stem) + '.md'
+    assert out_file.name == expected_name
+    assert out_file.exists()
+
+
+def test_md_filename_ascii(tmp_path):
+    pdf_name = 'ÆÐŐ file.pdf'
+    pdf_path = tmp_path / pdf_name
+    c = canvas.Canvas(str(pdf_path), pagesize=letter)
+    c.drawString(100, 750, 'ascii check')
+    c.save()
+
+    out_dir = tmp_path / 'out_ascii'
+    out_file = convert_pdf_to_md(pdf_path, out_dir, silent=True)
+
+    expected_name = slugify(pdf_path.stem) + '.md'
+    assert out_file.name == expected_name
+    assert all(ord(ch) < 128 for ch in out_file.name), 'Filename contains non-ASCII characters'


### PR DESCRIPTION
## Summary
- add regression test to ensure slugified Markdown filenames remain ASCII
- track slugified filename regression test in CHANGELOG, TODO, and ISSUES

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c910a27f883239e95dc21bd2c2fa3