### PR TITLE
Add filename sanitation script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 - Test ensures Markdown output is non-empty and ASCII
 - Removed pytest-of-root directory from repository and added to .gitignore
 - Filenames are now slugified to ASCII-only names with new tests
+- Added script to sanitize course filenames before conversion

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -2,6 +2,7 @@
 
 ## Open
 - [ ] Verify environment dependencies for OCR on all platforms
+- [ ] Add tests for sanitize_filenames script
 
 ## Closed
 - [x] Documented usage of PDF conversion script

--- a/TODO.md
+++ b/TODO.md
@@ -10,3 +10,5 @@
 - [ ] Add integration test for convert_folder script
 - [x] Remove pytest output directory from repository and ignore in git
 - [x] Slugify filenames for Markdown output
+- [x] Add script to sanitize course filenames before conversion
+- [ ] Add tests for sanitize_filenames script

--- a/scripts/sanitize_filenames.py
+++ b/scripts/sanitize_filenames.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Copy a directory tree with sanitized filenames.
+
+This script traverses an input directory (typically ``Courses``) and copies
+all files to a new output directory using ASCII-only slugified names.
+Directory structure is preserved but folder and file names are sanitized to
+avoid issues with spaces or accented characters.
+"""
+import argparse
+import shutil
+from pathlib import Path
+
+# Ensure project root is on path to import slugify
+import sys
+script_dir = Path(__file__).resolve().parent
+project_root = script_dir.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+if str(script_dir) in sys.path:
+    sys.path.remove(str(script_dir))
+
+from pdf_to_md.converter import slugify
+
+
+def sanitized_relative(path: Path, base: Path) -> Path:
+    """Return relative path with each part slugified."""
+    relative = path.relative_to(base)
+    return Path(*[slugify(part) for part in relative.parts])
+
+
+def copy_sanitized(input_dir: Path, output_dir: Path) -> None:
+    """Copy ``input_dir`` to ``output_dir`` with sanitized names."""
+    for item in input_dir.rglob("*"):
+        if item.is_dir():
+            continue
+        target_rel = sanitized_relative(item, input_dir)
+        target = output_dir / target_rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(item, target)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Copy a directory with sanitized filenames.")
+    parser.add_argument("input_dir", type=Path, help="Source directory to sanitize")
+    parser.add_argument("output_dir", type=Path, help="Destination directory for sanitized copy")
+    args = parser.parse_args()
+
+    copy_sanitized(args.input_dir, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- restore converter.py to clean state
- add script for sanitizing course filenames to ASCII-friendly names
- document new script in changelog, TODO, and issues log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68502a2087d4832382adfd90da986487