### PR TITLE
Add course planning optimizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@
 - Filenames are now slugified to ASCII-only names with new tests
 - Added course parser script generating CSV and semester JSON files
 - Made `parse_courses.py` executable for consistency
+- Implemented ILP-based course planner with CLI and tests

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -18,3 +18,4 @@
 - [x] Slugify filenames in converter and add test
 - [x] Implement course parser generating CSV and JSON
 - [x] Fix permission of parse_courses script
+- [x] Implement ILP-based course planner with tests

--- a/README.md
+++ b/README.md
@@ -94,3 +94,13 @@ python scripts/parse_courses.py Courses
 
 This will generate `courses.csv` and files like `fall2025_courses.json` in the
 current directory.
+
+### Planning a Schedule
+Once you have a `courses.csv` file you can generate a recommended schedule.
+
+```bash
+python scripts/plan_schedule.py courses.csv student.json certificate_rules.json
+```
+
+The script outputs a JSON file (default `schedule.json`) listing the selected
+courses under `selected_courses`.

--- a/TODO.md
+++ b/TODO.md
@@ -11,3 +11,4 @@
 - [x] Remove pytest output directory from repository and ignore in git
 - [x] Slugify filenames for Markdown output
 - [x] Add course parser script generating CSV and JSON
+- [x] Add course planning optimizer and CLI script

--- a/planner/optimizer.py
+++ b/planner/optimizer.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict, Any
+import csv
+import json
+import pulp
+
+
+def load_courses(path: Path) -> List[Dict[str, Any]]:
+    """Load courses from a CSV file."""
+    courses = []
+    with path.open(newline='', encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            days = row.get("days_offered", "")
+            days = [d.strip() for d in days.strip("[]").split(',') if d.strip()]
+            row["days_offered"] = days
+            courses.append(row)
+    return courses
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def plan_schedule(courses: List[Dict[str, Any]], student: Dict[str, Any], rules: Dict[str, Any]) -> Dict[str, Any]:
+    """Return selected course codes meeting rules and maximizing preferences."""
+    taken = set(student.get("courses_taken", []))
+    preferred_days = {d.lower() for d in student.get("preferred_days", [])}
+
+    prob = pulp.LpProblem("schedule", pulp.LpMaximize)
+    variables = {}
+    weights = {}
+    for i, course in enumerate(courses):
+        var = pulp.LpVariable(f"x_{i}", cat="Binary")
+        if course.get("course_code") in taken:
+            prob += var == 0
+        variables[i] = var
+        days = [d.lower() for d in course.get("days_offered", [])]
+        weights[i] = len(set(days) & preferred_days)
+
+    # Objective: maximize preferred day matches
+    prob += pulp.lpSum(weights[i] * variables[i] for i in variables)
+
+    for rule in rules.get("rules", []):
+        if rule.get("type") == "mandatory":
+            block = rule.get("block")
+            choose = int(rule.get("required", 0))
+            valid = [i for i, c in enumerate(courses) if c.get("block") == block]
+            prob += pulp.lpSum(variables[i] for i in valid) == choose
+        elif rule.get("type") == "elective":
+            choose = int(rule.get("choose", 0))
+            if "from" in rule:
+                valid = [
+                    i
+                    for i, c in enumerate(courses)
+                    if c.get("course_code") in rule["from"]
+                ]
+            else:
+                block = rule.get("block")
+                valid = [
+                    i
+                    for i, c in enumerate(courses)
+                    if c.get("block") == block
+                ]
+            prob += pulp.lpSum(variables[i] for i in valid) == choose
+
+    prob.solve(pulp.PULP_CBC_CMD(msg=False))
+
+    selected = [courses[i]["course_code"] for i in variables if pulp.value(variables[i]) == 1]
+    return {"selected_courses": selected}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pdfminer.six
 reportlab
 pytest
+pulp

--- a/scripts/plan_schedule.py
+++ b/scripts/plan_schedule.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Plan a course schedule using an ILP solver."""
+
+from pathlib import Path
+import argparse
+import json
+
+from planner.optimizer import load_courses, load_json, plan_schedule
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Plan course schedule")
+    parser.add_argument("courses_csv", type=Path, help="CSV file of courses")
+    parser.add_argument("student_json", type=Path, help="Student JSON file")
+    parser.add_argument("rules_json", type=Path, help="Certificate rules JSON")
+    parser.add_argument("-o", "--output", type=Path, default=Path("schedule.json"))
+    args = parser.parse_args()
+
+    courses = load_courses(args.courses_csv)
+    student = load_json(args.student_json)
+    rules = load_json(args.rules_json)
+
+    schedule = plan_schedule(courses, student, rules)
+
+    args.output.write_text(json.dumps(schedule, indent=2, ensure_ascii=False))
+    print(json.dumps(schedule, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import json
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from planner.optimizer import load_courses, load_json, plan_schedule
+
+
+def create_mock_data(tmp_path: Path):
+    csv_path = tmp_path / "courses.csv"
+    csv_path.write_text(
+        "course_code,course_title,block,days_offered,credits\n"
+        "CS200,Algorithms,Fundamentals,Wednesday,3\n"
+        "CS300,AI,Advanced Topics,Thursday,3\n"
+        "CS310,Graphics,Advanced Topics,Monday,3\n"
+    )
+
+    student = {
+        "student_name": "Test",
+        "courses_taken": [],
+        "preferred_days": ["Thursday", "Friday"]
+    }
+    student_path = tmp_path / "student.json"
+    student_path.write_text(json.dumps(student))
+
+    rules = {
+        "rules": [
+            {"type": "mandatory", "block": "Fundamentals", "required": 1},
+            {"type": "elective", "block": "Advanced Topics", "choose": 1, "from": ["CS300", "CS310"]}
+        ]
+    }
+    rules_path = tmp_path / "rules.json"
+    rules_path.write_text(json.dumps(rules))
+
+    return csv_path, student_path, rules_path
+
+
+def test_plan_schedule(tmp_path):
+    csv_path, student_path, rules_path = create_mock_data(tmp_path)
+    courses = load_courses(csv_path)
+    student = load_json(student_path)
+    rules = load_json(rules_path)
+
+    schedule = plan_schedule(courses, student, rules)
+    selected = schedule["selected_courses"]
+    assert set(selected) == {"CS200", "CS300"}


### PR DESCRIPTION
## Summary
- add an ILP-based course planning optimizer with CLI
- test the new planner on mock data
- document how to use the planner
- track progress in TODO/CHANGELOG/ISSUES
- add pulp to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68545833f05883238dd7108a4795e680