### PR TITLE
Add environment check tool and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,5 @@
 - Added course parser script generating CSV and semester JSON files
 - Made `parse_courses.py` executable for consistency
 - Implemented ILP-based course planner with CLI and tests
+- Environment check script verifying pdfminer.six, tesseract and pdftoppm
+- Installation instructions for macOS and Windows

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,9 +1,9 @@
 # Issues Log
 
 ## Open
-- [ ] Verify environment dependencies for OCR on all platforms
 
 ## Closed
+- [x] Verify environment dependencies for OCR on all platforms
 - [x] Documented usage of PDF conversion script
 - [x] Add integration test for convert_folder script
 - [x] Added initial test and basic repo maintenance files

--- a/README.md
+++ b/README.md
@@ -9,11 +9,25 @@ pip install -r requirements.txt
 ```
 
 ### System dependencies
-The PDF conversion script relies on external tools. On Debian/Ubuntu, install:
+The PDF conversion script relies on external tools. Below are quick installation
+steps for common platforms when running outside the provided Docker
+environment.
+
+**Debian/Ubuntu**
 ```bash
 sudo apt-get update && sudo apt-get install -y \
     tesseract-ocr \
     poppler-utils
+```
+
+**macOS (Homebrew)**
+```bash
+brew install tesseract poppler
+```
+
+**Windows (Chocolatey)**
+```powershell
+choco install tesseract poppler
 ```
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,3 +12,4 @@
 - [x] Slugify filenames for Markdown output
 - [x] Add course parser script generating CSV and JSON
 - [x] Add course planning optimizer and CLI script
+- [ ] Maintain environment check script

--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -1,0 +1,30 @@
+import importlib
+import shutil
+import sys
+
+
+def check_python_package(name: str) -> bool:
+    try:
+        importlib.import_module(name)
+        return True
+    except ImportError:
+        return False
+
+
+def check_executable(cmd: str) -> bool:
+    return shutil.which(cmd) is not None
+
+
+def main() -> int:
+    checks = {
+        'pdfminer.six': check_python_package('pdfminer'),
+        'tesseract': check_executable('tesseract'),
+        'pdftoppm': check_executable('pdftoppm'),
+    }
+    for item, ok in checks.items():
+        print(f"{item}: {'found' if ok else 'missing'}")
+    return 0 if all(checks.values()) else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_check_env.py
+++ b/tests/test_check_env.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import sys
+from unittest import mock
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import scripts.check_env as check_env
+
+
+def test_all_found(capsys):
+    with mock.patch.object(check_env, 'check_python_package', return_value=True), \
+         mock.patch.object(check_env, 'check_executable', return_value=True):
+        rc = check_env.main()
+        captured = capsys.readouterr().out
+    assert rc == 0
+    assert 'pdfminer.six: found' in captured
+    assert 'tesseract: found' in captured
+    assert 'pdftoppm: found' in captured
+
+
+def test_missing_tesseract(capsys):
+    with mock.patch.object(check_env, 'check_python_package', return_value=True), \
+         mock.patch.object(check_env, 'check_executable', side_effect=lambda cmd: False if cmd == 'tesseract' else True):
+        rc = check_env.main()
+        captured = capsys.readouterr().out
+    assert rc == 1
+    assert 'tesseract: missing' in captured


### PR DESCRIPTION
## Summary
- list tesseract and poppler install instructions for macOS and Windows
- add an environment check script and tests
- close the dependency verification issue
- record changes in changelog and todo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68545e0a20508323995141acbe963d91