### PR TITLE
Implement Markdown parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,5 @@
 - OCR fallback with tesseract/pdftoppm and --lang CLI option
 - Moved legacy pdfminer-only script to `scripts/legacy`
 - Test ensures Markdown output is non-empty and ASCII
+- Added Markdown parser converting `.md` timetables to JSON
+- New tests for parser and JSON export

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -13,3 +13,4 @@
 - [x] Set up automated PDF to markdown conversion
 - [x] Added script for batch PDF conversion by folder
 - [x] Validate Markdown output not empty via CLI test
+- [x] Implement Markdown→JSON parser

--- a/README.md
+++ b/README.md
@@ -84,11 +84,23 @@ corresponding Markdown files into sibling `.md` folders.
 python scripts/batch_pdf_to_md.py --root <project_root> --lang eng --silent
 ```
 
+## Parsing Markdown to JSON
+
+Once your `.md` files are generated you can convert them to structured JSON
+using the new parser module:
+
+```bash
+python -c "from md_parser import parse_semester; parse_semester(Path('Courses/winter2026/.md').parent)"
+```
+
+This command writes `data/winter2026.json` containing the schema described in
+`doc/OPTIMIZATION_GUIDE.md`.
+
 ## Building a conflict-free schedule (temporary workflow)
 
-Until the Markdown→JSON parser (see `TODO.md` task **P1**) is implemented,
-you can still evaluate the solver by providing a handcrafted JSON input (the
-expected schema is shown in the header comment of `scripts/solve_schedule.py`).
+With the Markdown parser in place you can convert a semester’s courses to JSON
+and feed it directly to the solver.  If you prefer, you may still craft the
+JSON manually following the schema shown in `scripts/solve_schedule.py`.
 
 ```bash
 python scripts/solve_schedule.py my_courses.json

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ Tasks are grouped by domain and ordered roughly by dependency.
 
 | ID | Priority | Task | Owner | Status |
 |----|----------|------|-------|--------|
-| P1 | 🔴 High | **Markdown→JSON parser** – extract course/section data from the OCR’d `.md` files into the schema in `doc/OPTIMIZATION_GUIDE.md`. | @data-eng | ❌ open |
+| P1 | 🔴 High | **Markdown→JSON parser** – extract course/section data from the OCR’d `.md` files into the schema in `doc/OPTIMIZATION_GUIDE.md`. | @data-eng | ✅ done |
 | P2 | 🔴 High | **Integration test**: PDF sample → `.md` → parser → JSON; assert schema & sample values. | @qa | ❌ open |
 | P3 | 🔴 High | **Add Tesseract to CI container** so OCR actually runs and `.md` outputs are populated. | @devops | ❌ open |
 | S1 | 🟠 Med  | Extend `course_scheduler` with **preference-aware scoring & local search** as outlined in the guide. | @algo | ⏳ WIP |

--- a/md_parser.py
+++ b/md_parser.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+"""Simple Markdown parser for UdeM course timetables."""
+
+import json
+import re
+from dataclasses import asdict
+from pathlib import Path
+from typing import List
+
+from course_scheduler.models import Course, Section
+
+_DAY_ABBR = {"Lun", "Ma", "Mer", "Jeu", "V", "Sam", "Dim"}
+
+
+def _semester_tag(semester: str) -> str:
+    """Return short code like ``W26`` from ``winter2026``."""
+    m = re.match(r"(winter|fall|summer)(20\d{2})", semester, re.IGNORECASE)
+    if not m:
+        return semester
+    season, year = m.groups()
+    letter = {
+        "winter": "W",
+        "fall": "F",
+        "summer": "S",
+    }[season.lower()]
+    return f"{letter}{year[-2:]}"
+
+
+def _find_semester(path: Path) -> str:
+    for p in path.parents:
+        m = re.match(r"(winter|fall|summer)20\d{2}", p.name, re.IGNORECASE)
+        if m:
+            return p.name
+    return ""
+
+
+def _course_to_dict(course: Course, semester: str) -> dict:
+    return {
+        "code": course.code,
+        "name": course.name,
+        "credits": course.credits,
+        "semester": semester,
+        "sections": [
+            {
+                "id": s.id,
+                "day": s.day,
+                "time": s.time,
+                "dates": s.dates,
+                "location": s.location,
+                **({"note": s.note} if s.note else {}),
+            }
+            for s in course.sections
+        ],
+    }
+
+
+def parse_markdown(path: Path) -> Course:
+    """Parse a Markdown file produced by :mod:`pdf_to_md` into a ``Course``."""
+    text = path.read_text(encoding="utf-8")
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        raise ValueError(f"No content in {path}")
+
+    header = lines[0]
+    m = re.match(r"(?P<code>\S+)\s*[-–]\s*(?P<name>.+)", header)
+    if not m:
+        raise ValueError(f"Cannot parse course header: {header}")
+    code = m.group("code")
+    name = m.group("name")
+
+    credits = 3.0
+    for ln in lines[1:3]:
+        m = re.search(r"(\d+(?:[.,]\d+)?)", ln)
+        if m:
+            credits = float(m.group(1).replace(",", "."))
+            break
+
+    semester = _find_semester(path)
+    tag = _semester_tag(semester) if semester else ""
+
+    sections: List[Section] = []
+    idx = 0
+    for ln in lines:
+        if not any(ln.startswith(d) for d in _DAY_ABBR):
+            continue
+        if "|" in ln:
+            parts = [p.strip() for p in ln.split("|")]
+        else:
+            parts = re.split(r"\s{2,}", ln)
+        if len(parts) < 4:
+            parts = ln.split()
+            if len(parts) < 5:
+                continue
+            day = parts[0]
+            time = " ".join(parts[1:4])
+            dates = parts[4]
+            location = " ".join(parts[5:]) if len(parts) > 5 else ""
+        else:
+            day, time, dates, location = parts[:4]
+        sec_id = f"{code}-{chr(65 + idx)}"
+        if tag:
+            sec_id += f"-{tag}"
+        sections.append(Section(id=sec_id, day=day, time=time, dates=dates, location=location))
+        idx += 1
+
+    return Course(code=code, name=name, credits=credits, sections=sections)
+
+
+def parse_semester(md_dir: Path, out_dir: Path = Path("data")) -> Path:
+    """Parse all ``.md`` files under *md_dir* and write JSON output."""
+    semester = _find_semester(md_dir)
+    if not semester:
+        semester = md_dir.name
+    courses = [parse_markdown(p) for p in sorted(md_dir.glob("*.md"))]
+    data = [_course_to_dict(c, semester) for c in courses]
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{semester}.json"
+    out_path.write_text(json.dumps(data, ensure_ascii=False, indent=2))
+    return out_path

--- a/tests/test_md_parser.py
+++ b/tests/test_md_parser.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from md_parser import parse_markdown, parse_semester
+
+
+SAMPLE_MD = """\
+IFT1410 - IA générative appliquée
+Crédits: 3
+
+Mer | 18:30 - 21:29 | 2026-01-07 → 2026-04-16 | En ligne
+Jeu | 18:30 - 21:29 | 2026-01-07 → 2026-04-16 | Campus
+"""
+
+
+def test_parse_markdown(tmp_path: Path):
+    md_file = tmp_path / "IFT1410 - IA générative appliquée.md"
+    md_file.write_text(SAMPLE_MD, encoding="utf-8")
+
+    course = parse_markdown(md_file)
+
+    assert course.code == "IFT1410"
+    assert course.name == "IA générative appliquée"
+    assert course.credits == 3
+    assert len(course.sections) == 2
+    assert course.sections[0].day == "Mer"
+    assert course.sections[0].time.startswith("18:30")
+
+
+def test_parse_semester(tmp_path: Path):
+    sem_dir = tmp_path / "winter2026" / ".md"
+    sem_dir.mkdir(parents=True)
+    md_file = sem_dir / "IFT1410 - IA générative appliquée.md"
+    md_file.write_text(SAMPLE_MD, encoding="utf-8")
+
+    out = parse_semester(sem_dir, out_dir=tmp_path)
+    data = out.read_text(encoding="utf-8")
+    assert "IFT1410" in data
+    assert out.name == "winter2026.json"


### PR DESCRIPTION
## Summary
- add `md_parser` module with `parse_markdown` and `parse_semester`
- test parser on sample markdown files
- document markdown parsing workflow in README
- update CHANGELOG, TODO and ISSUES

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ed88c86483238d8f021294e981ae