### PR TITLE
Implement local search and scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,5 @@
 - Added Markdown parser converting `.md` timetables to JSON
 - New tests for parser and JSON export
 - Added sample PDF and integration test for PDF→MD→JSON pipeline
+- Preference scoring constants and configurable local-search optimiser
+- Unit tests for scoring and optimiser behaviour

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -16,3 +16,4 @@
 - [x] Validate Markdown output not empty via CLI test
 - [x] Implement Markdown→JSON parser
 - [x] Add integration test for PDF→MD→JSON pipeline
+- [x] Implement local search optimiser with preference scoring constants

--- a/TODO.md
+++ b/TODO.md
@@ -11,9 +11,9 @@ Tasks are grouped by domain and ordered roughly by dependency.
 | P1 | 🔴 High | **Markdown→JSON parser** – extract course/section data from the OCR’d `.md` files into the schema in `doc/OPTIMIZATION_GUIDE.md`. | @data-eng | ✅ done |
 | P2 | 🔴 High | **Integration test**: PDF sample → `.md` → parser → JSON; assert schema & sample values. | @qa | ✅ done |
 | P3 | 🔴 High | **Add Tesseract to CI container** so OCR actually runs and `.md` outputs are populated. | @devops | ✅ done |
-| S1 | 🟠 Med  | Extend `course_scheduler` with **preference-aware scoring & local search** as outlined in the guide. | @algo | ⏳ WIP |
+| S1 | 🟠 Med  | Extend `course_scheduler` with **preference-aware scoring & local search** as outlined in the guide. | @algo | ✅ done |
 | S2 | 🟠 Med  | CLI wrapper `scripts/solve_schedule.py` – support multi-semester input, credit min/max flags, weight string. | @algo | ⏳ WIP |
-| S3 | 🟠 Med  | Write **unit tests for weight scoring** and local-search optimiser. | @qa | ❌ open |
+| S3 | 🟠 Med  | Write **unit tests for weight scoring** and local-search optimiser. | @qa | ✅ done |
 | UI1| 🟡 Low  | Build small REST endpoint (FastAPI) to serve generated schedules to the Tailwind UI. | @web | ❌ open |
 | UI2| 🟡 Low  | Modify `index.html` to fetch JSON from API instead of hard-coded `fullData`. | @web | ❌ open |
 | D1 | 🔵 Info | Review `doc/OPTIMIZATION_GUIDE.md` every sprint; keep protocol in sync with code. | @docs | 🆗 ongoing |

--- a/course_scheduler/__init__.py
+++ b/course_scheduler/__init__.py
@@ -4,8 +4,9 @@ Currently provides:
 
 • Basic dataclass models (Course, Section)
 • Utilities for parsing time strings and detecting conflicts
-• A naive back-tracking solver that finds a conflict-free section
-  combination for a list of courses.
+• A naive back-tracking solver + local search that finds a conflict-free
+  section combination for a list of courses while maximising soft
+  preferences.
 
 The solver is dependency-free (pure Python) so it runs in minimal
 environments such as the one used by the project’s CI.
@@ -14,4 +15,4 @@ environments such as the one used by the project’s CI.
 from __future__ import annotations
 
 from .models import Course, Section  # noqa: F401 – re-export for convenience
-from .solver import solve_schedule  # noqa: F401
+from .solver import score_sections, solve_schedule  # noqa: F401

--- a/doc/OPTIMIZATION_GUIDE.md
+++ b/doc/OPTIMIZATION_GUIDE.md
@@ -82,14 +82,15 @@ hundreds of courses.
 
 ## 5  Optimization algorithm (current)
 
-1. **Feasibility search** per semester using DFS (no weights yet).
+1. **Feasibility search** per semester using DFS.
 2. **Local improvement loop**:
-   * For every selected course, try alternative sections.
-   * Compute net preference delta; adopt change if score ↑ and constraints stay satisfied.
-   * Iterate until no improvement for two full passes.
+   * For each chosen section try the other sections of the same course.
+   * Compute the new preference score using the weights above.
+   * Adopt the alternative when the score increases and no hard constraint is violated.
+   * Repeat until a full pass yields no improvement.
 
-The score function uses preference weights from §3, so Wed/Thu/Fri moves are
-preferred and duplicate courses across semesters are automatically avoided.
+The scoring constants are implemented in ``course_scheduler.solver`` and can be
+overridden via the ``weights`` parameter of :func:`solve_schedule`.
 
 ---
 

--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -1,3 +1,5 @@
 # TODO
 
-- [ ] Document tasks here
+- [x] Add local search optimiser and scoring constants
+
+- [ ] Extend CLI wrapper with weight overrides

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,35 @@
+from course_scheduler import Course, Section, solve_schedule, score_sections
+
+
+def make_section(sid, day, loc="Campus"):
+    return Section(id=sid, day=day, time="18:30 - 21:29", dates="", location=loc)
+
+
+def test_score_sections():
+    secs = [
+        make_section("A", "Mer"),
+        make_section("B", "Jeu"),
+        make_section("C", "Lun", loc="B"),
+    ]
+    assert score_sections(secs) == 10 + 7 - 6 - 2
+
+
+def test_local_search_improves_solution():
+    c1 = Course(
+        code="IFT1000",
+        name="Intro",
+        credits=3,
+        sections=[make_section("A1", "Lun"), make_section("A2", "Mer")],
+    )
+    c2 = Course(
+        code="IFT2000",
+        name="Adv",
+        credits=3,
+        sections=[make_section("B1", "Ma")],
+    )
+
+    success, secs = solve_schedule([c1, c2])
+    assert success
+    days = {s.day for s in secs}
+    assert "Mer" in days
+    assert "Lun" not in days


### PR DESCRIPTION
## Summary
- add scoring weight constants and configurable score function
- implement local search optimizer in `solve_schedule`
- export score_sections
- document algorithm and update TODO/ISSUES
- add unit tests for scoring and search

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f49f168c8323bb512026f5027777