### PR TITLE
Add multi-semester solver CLI options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@
 - Added sample PDF and integration test for PDF→MD→JSON pipeline
 - Preference scoring constants and configurable local-search optimiser
 - Unit tests for scoring and optimiser behaviour
+- CLI solver accepts multiple JSON files, credit bounds and weight overrides

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -17,3 +17,4 @@
 - [x] Implement Markdown→JSON parser
 - [x] Add integration test for PDF→MD→JSON pipeline
 - [x] Implement local search optimiser with preference scoring constants
+- [x] Extend solver CLI with multi-file input and credit limits

--- a/README.md
+++ b/README.md
@@ -98,18 +98,17 @@ This command writes `data/winter2026.json` containing the schema described in
 
 ## Building a conflict-free schedule (temporary workflow)
 
-With the Markdown parser in place you can convert a semester’s courses to JSON
-and feed it directly to the solver.  If you prefer, you may still craft the
-JSON manually following the schema shown in `scripts/solve_schedule.py`.
+With the Markdown parser in place you can convert each semester’s courses to
+JSON and feed them directly to the solver.  The CLI now accepts multiple JSON
+files and credit limits:
 
 ```bash
-python scripts/solve_schedule.py my_courses.json
+python scripts/solve_schedule.py winter2026.json summer2026.json \
+    --min-credits 6 --max-credits 9 --weights wed=12,fri=8
 ```
 
 If a solution exists the script prints the chosen sections, one per line.  For
 small/medium course loads (< 50 courses) it finishes in a few milliseconds.
 
-The solver currently enforces time-conflict and duplication constraints.  A
-weighted preference optimiser and credit limits are planned – see tasks **S1
-– S3** in `TODO.md`.
+The solver currently enforces time-conflict and duplication constraints.
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@ Tasks are grouped by domain and ordered roughly by dependency.
 | P2 | 🔴 High | **Integration test**: PDF sample → `.md` → parser → JSON; assert schema & sample values. | @qa | ✅ done |
 | P3 | 🔴 High | **Add Tesseract to CI container** so OCR actually runs and `.md` outputs are populated. | @devops | ✅ done |
 | S1 | 🟠 Med  | Extend `course_scheduler` with **preference-aware scoring & local search** as outlined in the guide. | @algo | ✅ done |
-| S2 | 🟠 Med  | CLI wrapper `scripts/solve_schedule.py` – support multi-semester input, credit min/max flags, weight string. | @algo | ⏳ WIP |
+| S2 | 🟠 Med  | CLI wrapper `scripts/solve_schedule.py` – support multi-semester input, credit min/max flags, weight string. | @algo | ✅ done |
 | S3 | 🟠 Med  | Write **unit tests for weight scoring** and local-search optimiser. | @qa | ✅ done |
 | UI1| 🟡 Low  | Build small REST endpoint (FastAPI) to serve generated schedules to the Tailwind UI. | @web | ❌ open |
 | UI2| 🟡 Low  | Modify `index.html` to fetch JSON from API instead of hard-coded `fullData`. | @web | ❌ open |

--- a/scripts/solve_schedule.py
+++ b/scripts/solve_schedule.py
@@ -22,46 +22,107 @@ conflict-free combination exists the exit code is 1.
 
 from __future__ import annotations
 
-import argparse
-import json
 import sys
 from pathlib import Path
+
+# ensure project root on import path when executed directly
+script_dir = Path(__file__).resolve().parent
+project_root = script_dir.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+if str(script_dir) in sys.path:
+    sys.path.remove(str(script_dir))
+
+import argparse
+import json
 
 from course_scheduler import Course, Section, solve_schedule
 
 
-def load_courses(json_path: Path) -> list[Course]:
-    data = json.loads(json_path.read_text())
-    courses = []
-    for c in data:
-        courses.append(
-            Course(
-                code=c["code"],
-                name=c.get("name", c["code"]),
-                credits=c.get("credits", 3),
-                sections=[
-                    Section(
-                        id=s["id"],
-                        day=s["day"],
-                        time=s["time"],
-                        dates=s.get("dates", ""),
-                        location=s.get("location", ""),
-                        note=s.get("note"),
-                    )
-                    for s in c["sections"]
-                ],
+def load_courses(paths: list[Path]) -> list[Course]:
+    """Return a list of ``Course`` objects aggregated from all ``paths``."""
+
+    courses: list[Course] = []
+    for json_path in paths:
+        data = json.loads(json_path.read_text())
+        for c in data:
+            courses.append(
+                Course(
+                    code=c["code"],
+                    name=c.get("name", c["code"]),
+                    credits=c.get("credits", 3),
+                    sections=[
+                        Section(
+                            id=s["id"],
+                            day=s["day"],
+                            time=s["time"],
+                            dates=s.get("dates", ""),
+                            location=s.get("location", ""),
+                            note=s.get("note"),
+                        )
+                        for s in c["sections"]
+                    ],
+                )
             )
-        )
     return courses
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Compute a conflict-free schedule from JSON input.")
-    parser.add_argument("input_json", type=Path, help="Path to JSON file produced by the parser step")
+    parser = argparse.ArgumentParser(
+        description="Compute a conflict-free schedule from JSON input."
+    )
+    parser.add_argument(
+        "json_paths",
+        type=Path,
+        nargs="+",
+        help="Path(s) to JSON file(s) produced by the parser step",
+    )
+    parser.add_argument(
+        "--min-credits",
+        type=float,
+        default=0,
+        help="Minimum total credits required",
+    )
+    parser.add_argument(
+        "--max-credits",
+        type=float,
+        default=None,
+        help="Maximum total credits allowed",
+    )
+    parser.add_argument(
+        "--weights",
+        type=str,
+        help="Comma-separated key=value pairs overriding preference weights",
+    )
+
     args = parser.parse_args()
 
-    courses = load_courses(args.input_json)
-    ok, selected = solve_schedule(courses)
+    courses = load_courses(args.json_paths)
+
+    total_credits = sum(c.credits for c in courses)
+    if args.max_credits is not None and total_credits > args.max_credits:
+        print(
+            f"Total credits {total_credits} exceed max {args.max_credits}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if args.min_credits is not None and total_credits < args.min_credits:
+        print(
+            f"Total credits {total_credits} below min {args.min_credits}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    weights = None
+    if args.weights:
+        weights = {}
+        for item in args.weights.split(","):
+            if not item:
+                continue
+            key, val = item.split("=")
+            weights[key.strip()] = float(val)
+
+    ok, selected = solve_schedule(courses, weights=weights)
 
     if ok:
         print("Found schedule:\n")

--- a/tests/test_solve_cli.py
+++ b/tests/test_solve_cli.py
@@ -1,0 +1,42 @@
+import json
+import subprocess
+from pathlib import Path
+import sys
+
+from course_scheduler import Course
+
+
+def create_json(path: Path, code: str, day: str) -> Path:
+    data = [
+        {
+            "code": code,
+            "name": code,
+            "credits": 3,
+            "sections": [
+                {"id": f"{code}-A", "day": day, "time": "18:30 - 21:29", "dates": "", "location": "X"}
+            ],
+        }
+    ]
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def run_script(args):
+    script = Path(__file__).resolve().parents[1] / "scripts" / "solve_schedule.py"
+    return subprocess.run([sys.executable, str(script), *args], capture_output=True, text=True)
+
+
+def test_cli_multiple_files_success(tmp_path):
+    j1 = create_json(tmp_path / "s1.json", "C1", "Lun")
+    j2 = create_json(tmp_path / "s2.json", "C2", "Ma")
+    res = run_script([str(j1), str(j2), "--min-credits", "6", "--max-credits", "6", "--weights", "wed=20"])
+    assert res.returncode == 0
+    assert "Found schedule" in res.stdout
+
+
+def test_cli_credit_bounds_fail(tmp_path):
+    j1 = create_json(tmp_path / "s1.json", "C1", "Lun")
+    j2 = create_json(tmp_path / "s2.json", "C2", "Ma")
+    res = run_script([str(j1), str(j2), "--max-credits", "5"])
+    assert res.returncode == 1
+    assert "credits" in res.stderr.lower()


### PR DESCRIPTION
## Summary
- extend solver CLI to load multiple JSON files
- support `--min-credits`, `--max-credits` and `--weights` flags
- modify README usage to show new flags
- log new feature in CHANGELOG and ISSUES, mark TODO task done
- add regression tests for new CLI behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f63a41688323b7a8579656ca6daf